### PR TITLE
Feature/care request

### DIFF
--- a/src/main/java/hufs/likelion/gov/domain/matching/controller/CarePostController.java
+++ b/src/main/java/hufs/likelion/gov/domain/matching/controller/CarePostController.java
@@ -60,4 +60,16 @@ public class CarePostController {
         PatchCarePostResponse response = carePostService.finishCarePost(authentication, postId);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
+    //요청 수락
+    @PatchMapping("/accept/{postId}/{requestId}") //patch
+    public ResponseEntity<?> acceptCareRequest(Authentication authentication, @PathVariable("postId") Long postId, @PathVariable Long requestId) {
+        CareRequestResponse response = carePostService.acceptCareRequest(authentication, postId, requestId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+    //요청 거부
+    @PatchMapping("/reject/{postId}/{requestId}")
+    public ResponseEntity<?> rejectCareRequest(Authentication authentication, @PathVariable("postId") Long postId,  @PathVariable Long requestId) {
+        CareRequestResponse response = carePostService.rejectCareRequest(authentication, postId, requestId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
 }

--- a/src/main/java/hufs/likelion/gov/domain/matching/controller/CareRequestController.java
+++ b/src/main/java/hufs/likelion/gov/domain/matching/controller/CareRequestController.java
@@ -34,17 +34,4 @@ public class CareRequestController {
         List<CareRequestResponse> responses = careRequestService.findAllCareRequest(authentication);
         return new ResponseEntity<>(responses, HttpStatus.OK);
     }
-
-    //요청 수락
-//    @PatchMapping("/accept/{postId}") //patch
-//    public ResponseEntity<?> acceptCareRequest(Authentication authentication, @PathVariable("postId") Long postId) {
-//        CareRequestResponse response = careRequestService.acceptCareRequest(authentication, postId);
-//        return new ResponseEntity<>(response, HttpStatus.OK);
-//    }
-    //요청 거부
-//    @PatchMapping("/reject/{postId}")
-//    public ResponseEntity<?> rejectCareRequest(Authentication authentication, @PathVariable("postId") Long postId) {
-//        CareRequestResponse response = careRequestService.rejectCareRequest(authentication, postId);
-//        return new ResponseEntity<>(response, HttpStatus.OK);
-//    }
 }

--- a/src/main/java/hufs/likelion/gov/domain/matching/entity/CarePost.java
+++ b/src/main/java/hufs/likelion/gov/domain/matching/entity/CarePost.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/hufs/likelion/gov/domain/matching/service/CarePostService.java
+++ b/src/main/java/hufs/likelion/gov/domain/matching/service/CarePostService.java
@@ -7,19 +7,25 @@ import hufs.likelion.gov.domain.matching.entity.CareBaby;
 
 import hufs.likelion.gov.domain.matching.entity.CarePost;
 import hufs.likelion.gov.domain.matching.entity.CarePostStatus;
+import hufs.likelion.gov.domain.matching.entity.CareRequest;
+import hufs.likelion.gov.domain.matching.entity.MatchStatus;
 import hufs.likelion.gov.domain.matching.repository.CareBabyRepository;
 import hufs.likelion.gov.domain.matching.repository.CarePostRepository;
 
+import hufs.likelion.gov.domain.matching.repository.CareRequestRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static hufs.likelion.gov.domain.matching.dto.CareRequestResponse.toCareRequestResponse;
 import static hufs.likelion.gov.global.constant.GlobalConstant.*;
 
 @Service
@@ -29,7 +35,7 @@ public class CarePostService {
     private final CarePostRepository carePostRepository;
     private final CareBabyRepository careBabyRepository;
     private final MemberRepository memberRepository;
-
+    private final CareRequestRepository careRequestRepository;
     public GetCarePostsResponse findCarePosts(Pageable pageable){
         // write authentication code
         Page<CarePost> carePostsPage = carePostRepository.findAll(pageable);
@@ -132,5 +138,49 @@ public class CarePostService {
         return PatchCarePostResponse.builder()
                 .id(findCarePost.getId())
                 .build();
+    }
+
+    @Transactional
+    public CareRequestResponse acceptCareRequest(Authentication authentication, Long postId, Long requestId) {
+
+        Member requester = memberRepository.findById(requestId).orElseThrow();
+        CarePost carePost = carePostRepository.findById(postId).orElseThrow();
+        Member authMember = memberRepository.findByMemberId(authentication.getName()).orElseThrow();
+
+        if(authMember != carePost.getMember()){
+            throw new AccessDeniedException("요청 수락 권한이 없습니다.");
+        }
+
+        CareRequest careRequest = careRequestRepository.findByRequesterAndCarePost(requester, carePost);
+
+
+        if(careRequest.getStatus() == MatchStatus.REQUESTED){
+            careRequest.setStatus(MatchStatus.ACCEPTED);
+            careRequest.setCreatedAt(LocalDateTime.now());
+            return toCareRequestResponse(careRequest);
+        } else {
+            throw new AccessDeniedException("이미 수락된 요청입니다.");
+        }
+    }
+
+    @Transactional
+    public CareRequestResponse rejectCareRequest(Authentication authentication, Long postId, Long requestId) {
+        Member requester = memberRepository.findById(requestId).orElseThrow();
+        CarePost carePost = carePostRepository.findById(postId).orElseThrow();
+        Member authMember = memberRepository.findByMemberId(authentication.getName()).orElseThrow();
+
+        if(authMember != carePost.getMember()){
+            throw new AccessDeniedException("요청 거부 권한이 없습니다.");
+        }
+
+        CareRequest careRequest = careRequestRepository.findByRequesterAndCarePost(requester, carePost);
+
+        if(careRequest.getStatus() == MatchStatus.REQUESTED){
+            careRequest.setStatus(MatchStatus.REJECTED);
+            careRequest.setCreatedAt(LocalDateTime.now());
+            return toCareRequestResponse(careRequest);
+        } else {
+            throw new AccessDeniedException("이미 수락된 요청입니다.");
+        }
     }
 }

--- a/src/main/java/hufs/likelion/gov/domain/matching/service/CarePostService.java
+++ b/src/main/java/hufs/likelion/gov/domain/matching/service/CarePostService.java
@@ -157,6 +157,7 @@ public class CarePostService {
         if(careRequest.getStatus() == MatchStatus.REQUESTED){
             careRequest.setStatus(MatchStatus.ACCEPTED);
             careRequest.setCreatedAt(LocalDateTime.now());
+            carePost.setStatus(CarePostStatus.MATCHED);
             return toCareRequestResponse(careRequest);
         } else {
             throw new AccessDeniedException("이미 수락된 요청입니다.");

--- a/src/main/java/hufs/likelion/gov/domain/matching/service/CareRequestService.java
+++ b/src/main/java/hufs/likelion/gov/domain/matching/service/CareRequestService.java
@@ -44,35 +44,4 @@ public class CareRequestService {
             .map(CareRequestResponse::toCareRequestResponse)
             .toList();
     }
-
-
-    //요청 수락
-//    public CareRequestResponse acceptCareRequest(Authentication authentication, Long postId) {
-//        Member requester = memberRepository.findByMemberId(authentication.getName()).orElseThrow();
-//        CarePost carePost = carePostRepository.findById(postId).orElseThrow();
-//        CareRequest careRequest = careRequestRepository.findByRequesterAndCarePost(requester, carePost);
-//
-//        if(careRequest.getStatus() == MatchStatus.REQUESTED){
-//            careRequest.setStatus(MatchStatus.ACCEPTED);
-//            careRequest.setCreatedAt(LocalDateTime.now());
-//            return toCareRequestResponse(careRequest);
-//        } else {
-//            throw new AccessDeniedException("이미 수락된 요청입니다.");
-//        }
-//    }
-
-    //요청 거부
-//    public CareRequestResponse rejectCareRequest(Authentication authentication, Long postId) {
-//        Member requester = memberRepository.findByMemberId(authentication.getName()).orElseThrow();
-//        CarePost carePost = carePostRepository.findById(postId).orElseThrow();
-//        CareRequest careRequest = careRequestRepository.findByRequesterAndCarePost(requester, carePost);
-//
-//        if(careRequest.getStatus() == MatchStatus.REQUESTED){
-//            careRequest.setStatus(MatchStatus.REJECTED);
-//            careRequest.setCreatedAt(LocalDateTime.now());
-//            return toCareRequestResponse(careRequest);
-//        } else {
-//            throw new AccessDeniedException("이미 수락된 요청입니다.");
-//        }
-//    }
 }

--- a/src/main/java/hufs/likelion/gov/domain/review/dto/GetMemberReviewsData.java
+++ b/src/main/java/hufs/likelion/gov/domain/review/dto/GetMemberReviewsData.java
@@ -1,6 +1,6 @@
 package hufs.likelion.gov.domain.review.dto;
 
-import hufs.likelion.gov.domain.authentication.dto.GetMemberData;
+import hufs.likelion.gov.domain.authentication.dto.request.GetMemberData;
 import hufs.likelion.gov.domain.authentication.entity.Member;
 import hufs.likelion.gov.domain.review.entity.MemberReview;
 import hufs.likelion.gov.domain.review.entity.MemberReviewKeyword;

--- a/src/main/java/hufs/likelion/gov/global/constant/SecurityConfig.java
+++ b/src/main/java/hufs/likelion/gov/global/constant/SecurityConfig.java
@@ -55,8 +55,7 @@ public class SecurityConfig {
 							"/api/v1/complains/**"
 					).authenticated()
 					.requestMatchers(HttpMethod.PATCH,
-							"/api/v1/care/posts/**",
-              "/api/v1/care/requests/**"
+							"/api/v1/care/posts/**"
 					).authenticated()
 					.requestMatchers(HttpMethod.DELETE,
 							"/api/v1/care/posts/**"


### PR DESCRIPTION
## 📝작업 내용

> 돌봄 요청 및 수락 기능을 기존의 careRequest에서 carePost로 이동하여 로직을 재구성하였습니다.

>  따라서, api에 변동이 있었습니다. 확인 부탁드립니다.

> 돌봄 요청 수락 시 해당 post의 status를 MATCHED로 변경하도록 구현했습니다.

## 💬리뷰 요구사항

> 요청 수락 api : /accept/{postId}/{requestId} 로 구성하였는데, 보편적인 방법이 맞을까요?? 
(게시글에 요청한 요청의 개수가 여러개일 수 있다는 가능성에 requestId도 필요하다고 판단하여 추가하게 되었습니다.)
